### PR TITLE
perf: serve as static export with edge-friendly root redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ nohup.out
 **/package-lock.json
 .DS_Store
 **/.next/
+**/out/
 **/next-env.d.ts
 **/*.tsbuildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 **/.next/
+**/out/
 **/node_modules/
 **/yarn.lock
 **/next-env.d.ts

--- a/main/README.md
+++ b/main/README.md
@@ -14,5 +14,6 @@ yarn build
 ## Notes
 
 - Pages router (`pages/`)
-- `/` is rewritten to `/n` via `next.config.js`
+- Static export (`output: 'export'` in `next.config.js`) — `yarn build` writes `out/`
+- `/` is a static page that meta-refreshes to `/n`
 - Path alias `@/*` → project root

--- a/main/next.config.js
+++ b/main/next.config.js
@@ -3,13 +3,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: '/',
-        destination: '/n',
-      },
-    ]
+  output: 'export',
+  images: {
+    unoptimized: true,
   },
 }
 

--- a/main/pages/index.tsx
+++ b/main/pages/index.tsx
@@ -1,26 +1,16 @@
-import { useEffect } from 'react'
-
 import Head from 'next/head'
-import { Inter } from 'next/font/google'
-import styles from '@/styles/Home.module.css'
-
-import { useRouter } from 'next/router'
 import Link from 'next/link'
 
 export default function Home() {
-  const router = useRouter()
-  useEffect(() => {
-    // Always do navigations after the first render
-    router.push('/n', undefined, { shallow: true })
-  }, [])
   return (
     <>
       <Head>
+        <meta httpEquiv="refresh" content="0; url=/n" />
         <title>War.re</title>
         <meta name="description" content="Ryan Warren's Website" />
         <meta name="robots" content="index, follow" />
         <meta name="googlebot" content="index, follow" />
-        <link rel="canonical" href="https://war.re/" />
+        <link rel="canonical" href="https://war.re/n" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://war.re/n" />
         <meta property="og:title" content="Ryan Warren - Software Engineer" />
@@ -34,9 +24,9 @@ export default function Home() {
         <meta name="twitter:description" content="Seattle based SDE @ Stripe" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className={styles.main}>
+      <noscript>
         <Link href="/n">Click here to go to the main site</Link>
-      </main>
+      </noscript>
     </>
   )
 }

--- a/subdomains/ryan/README.md
+++ b/subdomains/ryan/README.md
@@ -15,6 +15,7 @@ yarn build
 ## Notes
 
 - Pages router (`pages/`)
-- `/` is rewritten to `/n` via `next.config.js`
+- Static export (`output: 'export'` in `next.config.js`) — `yarn build` writes `out/`
+- `/` is a static page that meta-refreshes to `/n`
 - Path alias `@/*` → project root
 - Jest + Testing Library for component tests

--- a/subdomains/ryan/next.config.js
+++ b/subdomains/ryan/next.config.js
@@ -3,13 +3,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: '/',
-        destination: '/n',
-      },
-    ]
+  output: 'export',
+  images: {
+    unoptimized: true,
   },
 }
 

--- a/subdomains/ryan/pages/index.tsx
+++ b/subdomains/ryan/pages/index.tsx
@@ -1,21 +1,11 @@
-import { useEffect } from 'react'
-
 import Head from 'next/head'
-import { Inter } from 'next/font/google'
-import styles from '@/styles/Home.module.css'
-
-import { useRouter } from 'next/router'
 import Link from 'next/link'
 
 export default function Home() {
-  const router = useRouter()
-  useEffect(() => {
-    // Always do navigations after the first render
-    router.push('/n', undefined, { shallow: true })
-  }, [])
   return (
     <>
       <Head>
+        <meta httpEquiv="refresh" content="0; url=/n" />
         <title>Ryan Warren - Resume</title>
         <meta
           name="description"
@@ -23,7 +13,7 @@ export default function Home() {
         />
         <meta name="robots" content="index, follow, noemailindex" />
         <meta name="googlebot" content="index, follow, noemailindex" />
-        <link rel="canonical" href="https://ryan.war.re/" />
+        <link rel="canonical" href="https://ryan.war.re/n" />
         <meta property="og:type" content="profile" />
         <meta property="og:url" content="https://ryan.war.re/n" />
         <meta property="og:title" content="Ryan Warren Resume" />
@@ -38,9 +28,9 @@ export default function Home() {
         <meta name="author" content="Ryan Warren" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className={styles.main}>
+      <noscript>
         <Link href="/n">Click here to go to the main site</Link>
-      </main>
+      </noscript>
     </>
   )
 }


### PR DESCRIPTION
## Summary

Three changes to both `main/` and `subdomains/ryan/`, all aimed at cutting bytes and round-trips on first paint:

1. **Static export.** Both apps now build with `output: 'export'` in `next.config.js`. Pages are fully prerendered HTML/CSS, served from a CDN with near-zero TTFB and no SSR cold start. `next/image` keeps working via `images: { unoptimized: true }`.
2. **Edge-fast `/` → `/n` redirect.** `pages/index.tsx` used to render a full React tree (with an unused `next/font/google` Inter import) and then `router.push('/n')` from a client `useEffect` — meaning users paid for an HTML fetch, a JS bundle, a font fetch, hydration, and *then* a client-side navigation. The new `pages/index.tsx` is a tiny page whose `<head>` contains `<meta http-equiv="refresh" content="0; url=/n">`. The browser follows the redirect during HTML parsing, before any JS or font is requested. SEO meta (canonical, OG, Twitter) is preserved.
3. **Drop the now-unnecessary `rewrites()`.** Static export doesn't support `rewrites()` and the meta refresh replaces it.

Also adds `out/` to `.gitignore` and `.prettierignore` so local exports don't leak into commits or trip `format:check`.

### Numbers (from `yarn build`)

| Route                | Before     | After (First Load JS) |
| -------------------- | ---------- | --------------------- |
| `main /`             | Full app + Inter font + hydration + client redirect | **643 B / 101 kB**, no font, no client redirect |
| `main /n`            | SSR'd      | 5.18 kB / 105 kB, prerendered |
| `ryan /`             | Full app + Inter font + hydration + client redirect | **669 B / 101 kB**, no font, no client redirect |
| `ryan /n`            | SSR'd      | 15.2 kB / 113 kB, prerendered |

### Deployment note

`yarn build` now writes to `out/` instead of `.next/`. `yarn start` no longer applies — point the host at the `out/` directory (Cloudflare Pages, Netlify, GitHub Pages, Vercel static, etc. all serve it directly). Both READMEs updated.

## Test plan

- [x] `yarn format:check && yarn lint && yarn typecheck && yarn build` passes for `main/`
- [x] `yarn test --ci && yarn format:check && yarn lint && yarn typecheck && yarn build` passes for `subdomains/ryan/`
- [ ] Smoke test the exported `out/` against current hosting (deploy preview or local static server)
- [ ] Verify `/` redirects to `/n` in a real browser (Chrome + Safari + Firefox)
- [ ] Confirm OG card still renders (Twitter / LinkedIn / iMessage preview)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KW6u1URgXuShNojYMXk4vw)_