### PR TITLE
fix(home): center page content and silence tsconfig warning

### DIFF
--- a/main/styles/Home.module.css
+++ b/main/styles/Home.module.css
@@ -1,6 +1,7 @@
 .main {
+  display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding: 6rem;
   min-height: 100vh;

--- a/main/tsconfig.json
+++ b/main/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
- Add display:flex to .main so existing flex props actually apply, and switch justify-content to center for vertical centering.
- Set moduleResolution to bundler so Next 16 stops rewriting tsconfig on every build.

Helped by the minions