### PR TITLE
refactor(site): drop dead css and fix cross-app drift

### DIFF
--- a/main/.prettierignore
+++ b/main/.prettierignore
@@ -1,0 +1,4 @@
+.next/
+out/
+yarn.lock
+next-env.d.ts

--- a/main/pages/n/index.tsx
+++ b/main/pages/n/index.tsx
@@ -37,9 +37,7 @@ export default function Home() {
       </Head>
       <main className={styles.main}>
         <div className={styles.center}>
-          <div className={styles.title}>
-            <h1>Ryan Warren</h1>
-          </div>
+          <h1>Ryan Warren</h1>
           <div className={styles.subtitle}>
             <h2>Software Engineer</h2>
           </div>

--- a/main/styles/Home.module.css
+++ b/main/styles/Home.module.css
@@ -7,22 +7,6 @@
   min-height: 100vh;
 }
 
-.description {
-  display: inherit;
-  justify-content: inherit;
-  align-items: inherit;
-  font-size: 0.85rem;
-  max-width: var(--max-width);
-  width: 100%;
-  z-index: 2;
-  font-family: var(--font-mono);
-}
-
-.grid {
-  grid-template-columns: repeat(4, minmax(25%, auto));
-  width: var(--max-width);
-  max-width: 100%;
-}
 .footer {
   text-align: center;
 }
@@ -39,11 +23,6 @@
   text-decoration: underline;
 }
 
-.title {
-}
-
-.subtitle {
-}
 .subtitle h2 {
   font-weight: normal;
 }
@@ -69,13 +48,4 @@
 
 .images img {
   margin-right: 15px;
-}
-
-@keyframes rotate {
-  from {
-    transform: rotate(360deg);
-  }
-  to {
-    transform: rotate(0deg);
-  }
 }

--- a/main/styles/globals.css
+++ b/main/styles/globals.css
@@ -1,97 +1,16 @@
 :root {
-  --max-width: 1100px;
-  --border-radius: 12px;
-  /*--font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',*/
-  /*  'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',*/
-  /*  'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;*/
   font-family:
-    Baskerville,
-    “Baskerville Old Face”,
-    “Hoefler Text”,
-    Garamond,
-    “Times New Roman”,
-    serif;
-  --font-mono:
-    Baskerville, “Baskerville Old Face”, “Hoefler Text”, Garamond, “Times New Roman”, serif;
-
-  /*--foreground-rgb: 0, 0, 0;*/
-  /*--background-start-rgb: 214, 219, 220;*/
-  /*--background-end-rgb: 255, 255, 255;*/
-
-  /*--primary-glow: conic-gradient(*/
-  /*  from 180deg at 50% 50%,*/
-  /*  #16abff33 0deg,*/
-  /*  #0885ff33 55deg,*/
-  /*  #54d6ff33 120deg,*/
-  /*  #0071ff33 160deg,*/
-  /*  transparent 360deg*/
-  /*);*/
-  /*--secondary-glow: radial-gradient(*/
-  /*  rgba(255, 255, 255, 1),*/
-  /*  rgba(255, 255, 255, 0)*/
-  /*);*/
-
-  /*--tile-start-rgb: 239, 245, 249;*/
-  /*--tile-end-rgb: 228, 232, 233;*/
-  /*--tile-border: conic-gradient(*/
-  /*  #00000080,*/
-  /*  #00000040,*/
-  /*  #00000030,*/
-  /*  #00000020,*/
-  /*  #00000010,*/
-  /*  #00000010,*/
-  /*  #00000080*/
-  /*);*/
-
-  /*--callout-rgb: 238, 240, 241;*/
-  /*--callout-border-rgb: 172, 175, 176;*/
-  /*--card-rgb: 180, 185, 188;*/
-  /*--card-border-rgb: 131, 134, 135;*/
+    Baskerville, 'Baskerville Old Face', 'Hoefler Text', Garamond, 'Times New Roman', serif;
   background-image: url(/small_steps.png);
-  /*display: flex;*/
 }
-.title {
-  /*display: flex;*/
-}
+
 h1 {
   font-weight: normal;
   font-size: 4em;
 }
+
 svg {
   padding: 0.2em;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    /*--foreground-rgb: 255, 255, 255;*/
-    /*--background-start-rgb: 0, 0, 0;*/
-    /*--background-end-rgb: 0, 0, 0;*/
-
-    /*--primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));*/
-    /*--secondary-glow: linear-gradient(*/
-    /*  to bottom right,*/
-    /*  rgba(1, 65, 255, 0),*/
-    /*  rgba(1, 65, 255, 0),*/
-    /*  rgba(1, 65, 255, 0.3)*/
-    /*);*/
-
-    /*--tile-start-rgb: 2, 13, 46;*/
-    /*--tile-end-rgb: 2, 5, 19;*/
-    /*--tile-border: conic-gradient(*/
-    /*  #ffffff80,*/
-    /*  #ffffff40,*/
-    /*  #ffffff30,*/
-    /*  #ffffff20,*/
-    /*  #ffffff10,*/
-    /*  #ffffff10,*/
-    /*  #ffffff80*/
-    /*);*/
-
-    /*--callout-rgb: 20, 20, 20;*/
-    /*--callout-border-rgb: 108, 108, 108;*/
-    /*--card-rgb: 100, 100, 100;*/
-    /*--card-border-rgb: 200, 200, 200;*/
-  }
 }
 
 * {
@@ -106,23 +25,7 @@ body {
   overflow-x: hidden;
 }
 
-body {
-  /*color: rgb(var(--foreground-rgb));*/
-  /*background: linear-gradient(*/
-  /*    to bottom,*/
-  /*    transparent,*/
-  /*    rgb(var(--background-end-rgb))*/
-  /*  )*/
-  /*  rgb(var(--background-start-rgb));*/
-}
-
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    /*color-scheme: dark;*/
-  }
 }

--- a/subdomains/ryan/.prettierignore
+++ b/subdomains/ryan/.prettierignore
@@ -1,0 +1,4 @@
+.next/
+out/
+yarn.lock
+next-env.d.ts

--- a/subdomains/ryan/components/Experience.tsx
+++ b/subdomains/ryan/components/Experience.tsx
@@ -1,12 +1,7 @@
 type ExperienceProps = {
-  // using `interface` is also ok
   heading: string
 }
 
 export default function Experience(props: ExperienceProps) {
-  return (
-    <>
-      <h2>{props.heading}</h2>
-    </>
-  )
+  return <h2>{props.heading}</h2>
 }

--- a/subdomains/ryan/styles/Home.module.css
+++ b/subdomains/ryan/styles/Home.module.css
@@ -53,34 +53,12 @@
   margin-bottom: 0.5em;
 }
 
-.rightSide {
-  float: left;
-  width: 50%;
-  margin-bottom: 1em;
-  margin-left: 1em;
-}
-
-.for {
-  font: bold 1em verdana;
-  text-transform: uppercase;
-}
-
 .main span {
   font-weight: normal;
   font-size: 0.8em;
   text-transform: none;
   float: right;
   margin-right: 1em;
-}
-
-.for span {
-  font-weight: normal;
-  text-transform: none;
-  float: right;
-}
-
-.as {
-  font: normal 1em verdana;
 }
 
 .main ul {
@@ -116,6 +94,21 @@
 .subline span {
   margin: 0;
   font-size: inherit;
+}
+
+.center {
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 4rem 0;
+  max-width: 40em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.info {
+  padding-top: 0.5em;
+  font-size: 1.1em;
 }
 
 @media screen and (min-width: 300px) and (max-width: 768px) {

--- a/subdomains/ryan/tsconfig.json
+++ b/subdomains/ryan/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Dead code (no behavior change):
- remove ~100 lines of commented-out boilerplate and unused vars in main globals.css
- drop unused .description/.grid/@keyframes and empty rules in main Home.module.css; unwrap dead .title wrapper in n/index
- drop unused .rightSide/.for/.as in ryan Home.module.css
- remove leftover scaffold comment and needless Fragment in Experience

Drift fixes:
- ryan 404 referenced styles.center/.info that don't exist in ryan's stylesheet (silent undefined) -- add them
- align ryan tsconfig moduleResolution node -> bundler (match main)
- fix invalid smart-quotes in main globals.css font-family
- add per-app .prettierignore so format:check ignores .next/ (the root ignore was never applied from app subdirs)

Helped by the minions