### PR TITLE
ci: add Codecov coverage for the ryan subdomain

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,3 +1,18 @@
+# Code coverage
+
+`subdomains/ryan` runs Jest with `--coverage` in CI and uploads the report to
+Codecov (`ci.yml` → `Upload coverage to Codecov`, scoped to the `ryan` flag —
+see `codecov.yml`). `main/` has no unit tests and is excluded from coverage; it
+is exercised by the Playwright UI smoke tests instead.
+
+## One-time setup
+
+Add `CODECOV_TOKEN` to the repo secrets so the upload authenticates:
+`Settings → Secrets and variables → Actions → New repository secret`. Get the
+token from [codecov.io](https://codecov.io) after connecting this repo. The
+upload step does not fail CI if the token is missing, but coverage will not be
+reported until it is set.
+
 # Dependabot automation
 
 This repo fully automates dependency updates end to end:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,13 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: subdomains/ryan/yarn.lock
       - run: yarn install --frozen-lockfile
-      - run: yarn test --ci
+      - run: yarn test --ci --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: subdomains/ryan/coverage/lcov.info
+          flags: ryan
       - run: yarn format:check
       - run: yarn lint
       - run: yarn typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nohup.out
 **/playwright-report/
 **/test-results/
 **/.playwright/
+**/coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 **/.next/
 **/out/
+**/coverage/
 **/node_modules/
 **/yarn.lock
 **/next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # war.re
 
+[![CI](https://github.com/rwwarren/war.re/actions/workflows/ci.yml/badge.svg)](https://github.com/rwwarren/war.re/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rwwarren/war.re/branch/main/graph/badge.svg)](https://codecov.io/gh/rwwarren/war.re)
+
 Personal site at [war.re](https://war.re) and resume at [ryan.war.re](https://ryan.war.re).
 
 ## Layout

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+# Coverage is only collected for subdomains/ryan (the only app with Jest tests).
+# main/ has no unit tests — it is covered by Playwright UI smoke tests in CI — so
+# it is ignored here to keep the coverage signal scoped to the tested app.
+coverage:
+  status:
+    project:
+      ryan:
+        target: auto
+        threshold: 1%
+        flags:
+          - ryan
+    patch:
+      default:
+        target: 90%
+        informational: true
+
+flags:
+  ryan:
+    paths:
+      - subdomains/ryan
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+
+ignore:
+  - "main/**"
+  - "**/*.test.*"
+  - "**/*.spec.*"
+  - "**/__tests__/**"
+  - "e2e/**"

--- a/subdomains/ryan/.prettierignore
+++ b/subdomains/ryan/.prettierignore
@@ -1,4 +1,5 @@
 .next/
 out/
+coverage/
 yarn.lock
 next-env.d.ts

--- a/subdomains/ryan/jest.config.js
+++ b/subdomains/ryan/jest.config.js
@@ -9,4 +9,16 @@ module.exports = createJestConfig({
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   // Playwright specs live in e2e/ and run via `yarn e2e`, not Jest.
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/e2e/'],
+  coverageReporters: ['text', 'lcov'],
+  collectCoverageFrom: [
+    '**/*.{ts,tsx}',
+    '!**/*.d.ts',
+    '!**/node_modules/**',
+    '!**/.next/**',
+    '!e2e/**',
+    '!jest.config.js',
+    '!jest.setup.ts',
+    '!next.config.*',
+    '!playwright.config.*',
+  ],
 })


### PR DESCRIPTION
Adds the one feature war.re was missing from the "code cov / assignments / tests / screenshots" set: **Codecov coverage reporting**.

## What changed
- `subdomains/ryan` runs Jest with `--coverage` in CI and uploads `lcov.info` to Codecov (`codecov-action@v5`, scoped to the `ryan` flag)
- `jest.config.js` — `lcov`/`text` reporters + `collectCoverageFrom` scoped to source `.ts(x)` (excludes configs, e2e, `.next`, type decls)
- `codecov.yml` — coverage scoped to `subdomains/ryan`; `main/` is excluded (no unit tests — covered by Playwright smoke tests). Patch target is informational so it won't block PRs touching the untested app
- README CI + Codecov badges
- `.gitignore` adds `**/coverage/`
- `AUTOMATION.md` documents the one-time `CODECOV_TOKEN` secret

## Verified locally
`yarn test --ci --coverage` passes (3 suites, 5 tests) and emits `subdomains/ryan/coverage/lcov.info` — the exact path CI uploads.

## One-time setup required
Add `CODECOV_TOKEN` to repo secrets (Settings → Secrets and variables → Actions) after connecting the repo on codecov.io. The upload step does **not** fail CI if the token is absent, so this won't block merges.

https://claude.ai/code/session_01My1C6j47seXKsCJvfJohU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01My1C6j47seXKsCJvfJohU9)_