### PR TITLE
ci: add Codecov coverage for the main site (e2e + unit)

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,9 +1,19 @@
 # Code coverage
 
-`subdomains/ryan` runs Jest with `--coverage` in CI and uploads the report to
-Codecov (`ci.yml` → `Upload coverage to Codecov`, scoped to the `ryan` flag —
-see `codecov.yml`). `main/` has no unit tests and is excluded from coverage; it
-is exercised by the Playwright UI smoke tests instead.
+Coverage uploads to Codecov under per-source flags (see `codecov.yml`); each
+upload step lives in `ci.yml`:
+
+- **`ryan`** — `subdomains/ryan` runs Jest with `--coverage`, uploading
+  `coverage/lcov.info`.
+- **`main`** — `main/` runs Jest with `--coverage` (`yarn test:coverage`),
+  uploading `coverage/lcov.info`.
+- **`main-e2e`** — supplements the `main` unit coverage with Playwright V8
+  coverage of what the browser actually executes. `yarn e2e:coverage`
+  (`COVERAGE=1`) collects V8 coverage during the smoke run, maps it back to
+  source via `monocart-coverage-reports` (`main/e2e/fixtures.ts` +
+  `global-setup`/`global-teardown`), and writes `main/coverage/e2e/lcov.info`.
+  Source maps are emitted by `productionBrowserSourceMaps` in `next.config.js`;
+  the report is scoped to `pages/`/`components/`/`lib/` source files.
 
 ## One-time setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
           cache-dependency-path: main/yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test:coverage --ci
+      - name: Upload unit coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: main/coverage/lcov.info
+          flags: main
       - run: yarn format:check
       - run: yarn lint
       - run: yarn typecheck
@@ -50,7 +56,13 @@ jobs:
       - name: Install Playwright browser
         run: yarn playwright install --with-deps chromium
       - name: UI smoke tests
-        run: yarn e2e
+        run: yarn e2e:coverage
+      - name: Upload e2e coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: main/coverage/e2e/lcov.info
+          flags: main-e2e
 
   ryan-site:
     name: Ryan Subdomain (ryan.war.re)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
-# Coverage is only collected for subdomains/ryan (the only app with Jest tests).
-# main/ has no unit tests — it is covered by Playwright UI smoke tests in CI — so
-# it is ignored here to keep the coverage signal scoped to the tested app.
+# Coverage is collected per app and source, each under its own flag:
+#   - ryan:    Jest unit tests in subdomains/ryan
+#   - main:    Jest unit tests in main/
+#   - main-e2e: Playwright V8 coverage from main/'s UI smoke tests (what the
+#     browser actually executes, complementing the unit tests)
 coverage:
   status:
     project:
@@ -9,6 +11,16 @@ coverage:
         threshold: 1%
         flags:
           - ryan
+      main:
+        target: auto
+        threshold: 1%
+        flags:
+          - main
+      main-e2e:
+        target: auto
+        threshold: 1%
+        flags:
+          - main-e2e
     patch:
       default:
         target: 90%
@@ -19,13 +31,20 @@ flags:
     paths:
       - subdomains/ryan
     carryforward: true
+  main:
+    paths:
+      - main
+    carryforward: true
+  main-e2e:
+    paths:
+      - main
+    carryforward: true
 
 comment:
   layout: "reach, diff, flags, files"
   require_changes: true
 
 ignore:
-  - "main/**"
   - "**/*.test.*"
   - "**/*.spec.*"
   - "**/__tests__/**"

--- a/main/e2e/coverage-options.ts
+++ b/main/e2e/coverage-options.ts
@@ -1,0 +1,23 @@
+import type { CoverageReportOptions } from 'monocart-coverage-reports'
+
+// Shared monocart config for the Playwright V8 coverage run. Writes to
+// `coverage/e2e/` so it doesn't collide with Jest's `coverage/lcov.info`; keep
+// the path in sync with the `main-e2e` Codecov upload step in ci.yml.
+export const coverageOptions: CoverageReportOptions = {
+  name: 'war.re main e2e coverage',
+  outputDir: './coverage/e2e',
+  reports: [['lcovonly', { file: 'lcov.info' }], ['console-summary']],
+  // After source-map resolution, keep only this app's TS/JS source files
+  // (drops Next manifests, the webpack runtime, and CSS-module pseudo-entries).
+  sourceFilter: (sourcePath) =>
+    /\/(pages|components|lib)\//.test(sourcePath) &&
+    /\.(ts|tsx|js|jsx)$/.test(sourcePath) &&
+    !sourcePath.includes('node_modules'),
+  // Turbopack emits sources under `[project]/`; rewrite to repo-root-relative
+  // paths so Codecov matches them against `main/...` in the tree. Idempotent —
+  // monocart invokes this on both `add` and `generate`.
+  sourcePath: (filePath) => {
+    const rel = filePath.replace(/^\[project\]\//, '')
+    return rel.startsWith('main/') ? rel : `main/${rel}`
+  },
+}

--- a/main/e2e/fixtures.ts
+++ b/main/e2e/fixtures.ts
@@ -1,0 +1,42 @@
+import { test as base, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { CoverageReport } from 'monocart-coverage-reports'
+import { coverageOptions } from './coverage-options'
+
+const collectCoverage = !!process.env.COVERAGE
+
+// Opt-in V8 coverage (COVERAGE=1, via `yarn e2e:coverage`). The static export is
+// served from `out/`, so each chunk's source map sits at `out/<pathname>.map`;
+// attach it explicitly rather than relying on http resolution of sourceMappingURL.
+export const test = base.extend({
+  page: async ({ page, browserName }, use) => {
+    const enabled = collectCoverage && browserName === 'chromium'
+    if (enabled) {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false })
+    }
+
+    // `use` is the Playwright fixture API, not a React hook.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    await use(page)
+
+    if (enabled) {
+      const entries = await page.coverage
+        .stopJSCoverage()
+        .then((list) => list.filter((entry) => entry.url.includes('/_next/static/chunks/')))
+      // Attach each chunk's source map from the served `out/` dir when present;
+      // unmapped chunks pass through and are dropped later by `sourceFilter`.
+      const withMaps = entries.map((entry) => {
+        const mapFile = path.join('out', `${new URL(entry.url).pathname}.map`)
+        try {
+          return { ...entry, sourceMap: JSON.parse(readFileSync(mapFile, 'utf8')) }
+        } catch {
+          return entry
+        }
+      })
+      await new CoverageReport(coverageOptions).add(withMaps)
+    }
+  },
+})
+
+export { expect }

--- a/main/e2e/global-setup.ts
+++ b/main/e2e/global-setup.ts
@@ -1,0 +1,7 @@
+import { CoverageReport } from 'monocart-coverage-reports'
+import { coverageOptions } from './coverage-options'
+
+export default async function globalSetup() {
+  if (!process.env.COVERAGE) return
+  await new CoverageReport(coverageOptions).cleanCache()
+}

--- a/main/e2e/global-teardown.ts
+++ b/main/e2e/global-teardown.ts
@@ -1,0 +1,7 @@
+import { CoverageReport } from 'monocart-coverage-reports'
+import { coverageOptions } from './coverage-options'
+
+export default async function globalTeardown() {
+  if (!process.env.COVERAGE) return
+  await new CoverageReport(coverageOptions).generate()
+}

--- a/main/e2e/smoke.spec.ts
+++ b/main/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 
 test.describe('war.re main site', () => {
   test('content route renders the homepage', async ({ page }) => {

--- a/main/next.config.js
+++ b/main/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
+  // Emit browser source maps so Playwright V8 coverage maps back to source
+  // (see e2e/fixtures.ts). Only consumed by the coverage tooling; harmless in prod.
+  productionBrowserSourceMaps: true,
   images: {
     unoptimized: true,
   },

--- a/main/package.json
+++ b/main/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier --check .",
     "test": "jest --passWithNoTests",
     "test:coverage": "jest --passWithNoTests --coverage",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:coverage": "COVERAGE=1 playwright test"
   },
   "dependencies": {
     "@types/node": "25.9.1",
@@ -34,6 +35,7 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
+    "monocart-coverage-reports": "^2.12.12",
     "prettier": "^3.3.3",
     "serve": "^14.2.4"
   },

--- a/main/playwright.config.ts
+++ b/main/playwright.config.ts
@@ -10,6 +10,8 @@ const baseURL = `http://127.0.0.1:${PORT}`
  */
 export default defineConfig({
   testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/main/yarn.lock
+++ b/main/yarn.lock
@@ -1661,7 +1661,21 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.15.0:
+acorn-loose@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/acorn-loose/-/acorn-loose-8.5.2.tgz#a7cc7dfbb7c8f3c2e55b055db640dc657e278d26"
+  integrity sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==
+  dependencies:
+    acorn "^8.15.0"
+
+acorn-walk@^8.3.5:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -2164,6 +2178,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
+
 compressible@~2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -2183,6 +2202,11 @@ compression@1.8.1:
     on-headers "~1.1.0"
     safe-buffer "5.2.1"
     vary "~1.1.2"
+
+console-grid@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/console-grid/-/console-grid-2.2.4.tgz#115216b2fde9d245cad0ee9faefa901f680aa6a4"
+  integrity sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -2370,6 +2394,11 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+eight-colors@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/eight-colors/-/eight-colors-1.3.3.tgz#d4b9d124929f8a57eaeb04fc7af35261e1891f24"
+  integrity sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==
 
 electron-to-chromium@^1.5.328:
   version "1.5.357"
@@ -2907,6 +2936,13 @@ foreground-child@^3.1.0:
   integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
   dependencies:
     cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
+foreground-child@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-4.0.3.tgz#e02d55326b54e4e311a5a292cfc30c2e076949f1"
+  integrity sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==
+  dependencies:
     signal-exit "^4.0.1"
 
 fs.realpath@^1.0.0:
@@ -3477,7 +3513,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
@@ -3493,7 +3529,7 @@ istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
     istanbul-lib-coverage "^3.2.0"
     semver "^7.5.4"
 
-istanbul-lib-report@^3.0.0:
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
   integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
@@ -3511,7 +3547,7 @@ istanbul-lib-source-maps@^5.0.0:
     debug "^4.1.1"
     istanbul-lib-coverage "^3.0.0"
 
-istanbul-reports@^3.1.3:
+istanbul-reports@^3.1.3, istanbul-reports@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
   integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
@@ -4083,6 +4119,11 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
+lz-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/lz-utils/-/lz-utils-2.1.1.tgz#78958062d0f4be37e8ff127f710997bc558143be"
+  integrity sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -4177,6 +4218,29 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+monocart-coverage-reports@^2.12.12:
+  version "2.12.12"
+  resolved "https://registry.yarnpkg.com/monocart-coverage-reports/-/monocart-coverage-reports-2.12.12.tgz#ec96f23956f4bb1461241bdc9f1df0fc542a9f37"
+  integrity sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==
+  dependencies:
+    acorn "^8.16.0"
+    acorn-loose "^8.5.2"
+    acorn-walk "^8.3.5"
+    commander "^14.0.3"
+    console-grid "^2.2.4"
+    eight-colors "^1.3.3"
+    foreground-child "^4.0.3"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    lz-utils "^2.1.1"
+    monocart-locator "^1.0.3"
+
+monocart-locator@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/monocart-locator/-/monocart-locator-1.0.3.tgz#476ddc4956efcfbda5470bb1c8b986a54b68307a"
+  integrity sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What

Wires main-site coverage to Codecov, building on #81 (which added Jest tests to `main/` but never uploaded their coverage). Adds two complementary flags:

- **`main`** — `main/`'s Jest unit coverage (`yarn test:coverage` → `main/coverage/lcov.info`), mirroring the `ryan` setup.
- **`main-e2e`** — Playwright V8 coverage of what the browser actually executes during the UI smoke tests, a different signal from the unit tests.

## How

- **`ci.yml`** — `main-site` job now uploads the Jest lcov under `main`, and (after `yarn e2e:coverage`) the V8 lcov under `main-e2e`.
- **`e2e/fixtures.ts`** — opt-in (`COVERAGE=1`) `page` fixture that collects V8 coverage and attaches each chunk's source map from `out/`. Plain `yarn e2e` is unchanged.
- **`e2e/coverage-options.ts` + `global-setup`/`global-teardown`** — monocart config; writes to `coverage/e2e/` (separate dir so it doesn't clobber the Jest report), scopes sources to `pages/`/`components/`/`lib/`, rewrites Turbopack's `[project]/` to `main/...`.
- **`next.config.js`** — `productionBrowserSourceMaps: true` so V8 coverage maps back to source.
- **`package.json`** — adds `monocart-coverage-reports` + `e2e:coverage` script.
- **`codecov.yml`** — drops the `main/**` ignore; adds `main` and `main-e2e` flags + statuses.

## Notes

- Rebased onto #81. `CODECOV_TOKEN` already exists from #82 — no new secret needed.
- Verified locally: Jest (`coverage/lcov.info` → `pages/n/index.tsx`) and Playwright (`coverage/e2e/lcov.info` → `main/pages/*`) coexist without collision; `lint`/`format:check`/`typecheck` pass.

Helped by the minions