### PR TITLE
docs: document yarn typecheck in app READMEs

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -8,6 +8,7 @@ Next.js app served at [war.re](https://war.re).
 yarn install
 yarn dev      # localhost:3000
 yarn lint
+yarn typecheck
 yarn build
 ```
 

--- a/subdomains/ryan/README.md
+++ b/subdomains/ryan/README.md
@@ -8,6 +8,7 @@ Next.js app served at [ryan.war.re](https://ryan.war.re).
 yarn install
 yarn dev      # localhost:3000
 yarn lint
+yarn typecheck
 yarn test
 yarn build
 ```


### PR DESCRIPTION
Adds the existing `yarn typecheck` script to the dev command list in both app READMEs (it was missing).

Doubles as the smoke test for the dependency-merge Slack workflow from #74 — carries the `dependencies` label so merging it fires the notify job.

**Sequencing:** #74 must merge to main first (the workflow runs from the base branch under `pull_request_target`), then merging this fires the Slack post.

Helped by the minions