### PR TITLE
chore(ci): skip draft PRs, dedupe branch CI runs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   assign:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   assign:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [main, 'claude/**']
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       main: ${{ steps.filter.outputs.main }}

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -9,6 +9,9 @@ name: PR screenshots
 
 on:
   pull_request:
+    # Include ready_for_review so marking a draft ready re-triggers the capture
+    # (the draft gate below skips it while the PR is a draft).
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write
@@ -18,8 +21,11 @@ jobs:
   capture:
     # Same-repo PRs only (this includes Dependabot, whose branches live in the
     # repo). Fork PRs are skipped entirely, so untrusted fork code is never
-    # built or run by this automation.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # built or run by this automation. Also skip drafts — screenshots are a
+    # review aid, so capturing them on every draft push just burns CI hours.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Gate `ci.yml` (via the `changes` entry job, which the rest of the graph depends on), `auto-assign.yml`, and `pr-screenshots.yml` on `github.event.pull_request.draft == false`.
- Add a `concurrency` group to `ci.yml` (cancel-in-progress, main exempted).
- Drop `claude/**` from `ci.yml`'s push trigger — it was causing CI to run twice per push once a PR exists on that branch (push event + pull_request event, different refs, so concurrency didn't dedupe them). Branch CI now relies solely on the pull_request trigger.
- `pr-screenshots.yml` gains `ready_for_review` in its trigger types so marking a draft ready re-triggers the capture, matching `draft-app`'s existing pattern.

`ci-passed`'s existing `if: always()` gate already tolerates skipped upstream jobs (only fails on `failure`/`cancelled`), so it correctly reports success when `changes` is skipped for a draft PR — verified by reading the job logic before relying on the cascade.