### PR TITLE
fix(ci): bump Node from 20 to 22 in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: main/yarn.lock
       - run: yarn install --frozen-lockfile
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: subdomains/ryan/yarn.lock
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: |
             main/yarn.lock

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: |
             main/yarn.lock


### PR DESCRIPTION
@testing-library/jest-dom@7.0.0 requires Node >=22, which breaks yarn install on every PR since it was picked up (blocking all open Dependabot PRs). dependabot-resolutions.yml already runs on Node 22; align ci.yml, update-snapshots.yml, and pr-screenshots.yml to match.

Verified locally on Node 22.20.0: yarn install, test:coverage, lint, format:check, and typecheck all pass for both main and subdomains/ryan.