### PR TITLE
Add light/dark/system theme toggle with saved preference

### DIFF
--- a/main/components/ThemeToggle.module.css
+++ b/main/components/ThemeToggle.module.css
@@ -2,12 +2,15 @@
   position: fixed;
   top: 0.75rem;
   right: 0.75rem;
-  display: inline-flex;
-  gap: 0.15rem;
   padding: 0.2rem;
   border-radius: 999px;
   background: rgba(127, 127, 127, 0.15);
   z-index: 10;
+}
+
+.group {
+  display: inline-flex;
+  gap: 0.15rem;
 }
 
 .toggle button {

--- a/main/components/ThemeToggle.module.css
+++ b/main/components/ThemeToggle.module.css
@@ -1,0 +1,43 @@
+.toggle {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  gap: 0.15rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  background: rgba(127, 127, 127, 0.15);
+  z-index: 10;
+}
+
+.toggle button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.7rem;
+  line-height: 1;
+  padding: 0.4rem 0.55rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.toggle button:hover {
+  background: rgba(127, 127, 127, 0.25);
+}
+
+.toggle .active {
+  background: rgba(127, 127, 127, 0.4);
+  font-weight: bold;
+}
+
+.toggle button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media print {
+  .toggle {
+    display: none;
+  }
+}

--- a/main/components/ThemeToggle.module.css
+++ b/main/components/ThemeToggle.module.css
@@ -6,6 +6,20 @@
   border-radius: 999px;
   background: rgba(127, 127, 127, 0.15);
   z-index: 10;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.toggle.hidden {
+  transform: translateY(-150%);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toggle {
+    transition: none;
+  }
 }
 
 .group {

--- a/main/components/ThemeToggle.tsx
+++ b/main/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from 'react'
+import styles from './ThemeToggle.module.css'
+import {
+  applyTheme,
+  getServerTheme,
+  getStoredTheme,
+  storeTheme,
+  subscribeTheme,
+  type Theme,
+} from '@/lib/theme'
+
+const OPTIONS: Array<{ value: Theme; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+]
+
+export default function ThemeToggle() {
+  // The server (and first client render, for hydration) always see
+  // 'system'; useSyncExternalStore then swaps in the real saved preference.
+  const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+
+  function choose(next: Theme) {
+    storeTheme(next)
+    applyTheme(next)
+  }
+
+  return (
+    <div className={styles.toggle} role="radiogroup" aria-label="Color theme">
+      {OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={theme === option.value}
+          className={theme === option.value ? styles.active : undefined}
+          onClick={() => choose(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/main/components/ThemeToggle.tsx
+++ b/main/components/ThemeToggle.tsx
@@ -34,19 +34,24 @@ export default function ThemeToggle() {
   }
 
   return (
-    <div className={styles.toggle} role="radiogroup" aria-label="Color theme">
-      {OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          role="radio"
-          aria-checked={theme === option.value}
-          className={theme === option.value ? styles.active : undefined}
-          onClick={() => choose(option.value)}
-        >
-          {option.label}
-        </button>
-      ))}
+    // A fixed-position control sitting outside the page's <main> needs its
+    // own landmark, or axe's "region" check flags it as content unreachable
+    // via landmark navigation — hence the wrapping role="region".
+    <div className={styles.toggle} role="region" aria-label="Theme">
+      <div className={styles.group} role="radiogroup" aria-label="Color theme">
+        {OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={theme === option.value}
+            className={theme === option.value ? styles.active : undefined}
+            onClick={() => choose(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/main/components/ThemeToggle.tsx
+++ b/main/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import styles from './ThemeToggle.module.css'
 import {
   applyTheme,
@@ -17,12 +17,20 @@ const OPTIONS: Array<{ value: Theme; label: string }> = [
 
 export default function ThemeToggle() {
   // The server (and first client render, for hydration) always see
-  // 'system'; useSyncExternalStore then swaps in the real saved preference.
+  // 'system'; useSyncExternalStore then swaps in the real saved preference
+  // — including a preference changed in another tab via the 'storage'
+  // event (see subscribeTheme).
   const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+
+  // Keep the DOM in sync with `theme` from any source — a click below, or
+  // a change made in another tab. Reapplying the already-current theme
+  // (e.g. right after hydration) is a harmless no-op.
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
 
   function choose(next: Theme) {
     storeTheme(next)
-    applyTheme(next)
   }
 
   return (

--- a/main/components/ThemeToggle.tsx
+++ b/main/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import styles from './ThemeToggle.module.css'
 import {
   applyTheme,
@@ -15,12 +15,22 @@ const OPTIONS: Array<{ value: Theme; label: string }> = [
   { value: 'dark', label: 'Dark' },
 ]
 
+// Below this scroll offset the toggle always shows, so it doesn't
+// flicker away from tiny scrolls (mobile bounce, sub-pixel jitter) right
+// at the top of the page.
+const ALWAYS_VISIBLE_BELOW_Y = 8
+// Minimum scroll delta (in either direction) before we react, so a resting
+// thumb or trackpad jitter can't toggle visibility on its own.
+const DIRECTION_THRESHOLD = 4
+
 export default function ThemeToggle() {
   // The server (and first client render, for hydration) always see
   // 'system'; useSyncExternalStore then swaps in the real saved preference
   // — including a preference changed in another tab via the 'storage'
   // event (see subscribeTheme).
   const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+  const [hidden, setHidden] = useState(false)
+  const lastScrollY = useRef(0)
 
   // Keep the DOM in sync with `theme` from any source — a click below, or
   // a change made in another tab. Reapplying the already-current theme
@@ -29,6 +39,28 @@ export default function ThemeToggle() {
     applyTheme(theme)
   }, [theme])
 
+  // Hide the toggle while scrolling down (it would otherwise sit over page
+  // content) and bring it back on scroll up or near the top.
+  useEffect(() => {
+    lastScrollY.current = window.scrollY
+
+    function onScroll() {
+      const y = window.scrollY
+      const delta = y - lastScrollY.current
+      if (y <= ALWAYS_VISIBLE_BELOW_Y) {
+        setHidden(false)
+      } else if (delta > DIRECTION_THRESHOLD) {
+        setHidden(true)
+      } else if (delta < -DIRECTION_THRESHOLD) {
+        setHidden(false)
+      }
+      lastScrollY.current = y
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
   function choose(next: Theme) {
     storeTheme(next)
   }
@@ -36,8 +68,15 @@ export default function ThemeToggle() {
   return (
     // A fixed-position control sitting outside the page's <main> needs its
     // own landmark, or axe's "region" check flags it as content unreachable
-    // via landmark navigation — hence the wrapping role="region".
-    <div className={styles.toggle} role="region" aria-label="Theme">
+    // via landmark navigation — hence the wrapping role="region". `inert`
+    // while hidden drops it from the tab order and hit-testing, so it can't
+    // trap keyboard focus or clicks while off-screen.
+    <div
+      className={hidden ? `${styles.toggle} ${styles.hidden}` : styles.toggle}
+      role="region"
+      aria-label="Theme"
+      inert={hidden || undefined}
+    >
       <div className={styles.group} role="radiogroup" aria-label="Color theme">
         {OPTIONS.map((option) => (
           <button

--- a/main/lib/theme.ts
+++ b/main/lib/theme.ts
@@ -1,0 +1,76 @@
+export type Theme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'theme'
+const listeners = new Set<() => void>()
+
+function isTheme(value: unknown): value is 'light' | 'dark' {
+  return value === 'light' || value === 'dark'
+}
+
+// Returns the user's saved preference, or 'system' if none was saved (the
+// default). Safe to call during server rendering — returns 'system'.
+export function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system'
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    return isTheme(value) ? value : 'system'
+  } catch {
+    // localStorage can throw (private browsing, disabled storage, etc).
+    return 'system'
+  }
+}
+
+// A stable 'system' snapshot for server rendering / hydration, so
+// useSyncExternalStore never sees a value that could mismatch the markup
+// the server produced.
+export function getServerTheme(): Theme {
+  return 'system'
+}
+
+export function storeTheme(theme: Theme): void {
+  try {
+    if (theme === 'system') {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, theme)
+    }
+  } catch {
+    // Ignore — the theme still applies for this page load via applyTheme.
+  }
+  listeners.forEach((listener) => listener())
+}
+
+// Reflects the chosen theme onto the document so CSS can key off it. Leaving
+// the attribute unset for 'system' lets the existing prefers-color-scheme
+// media queries keep driving the look.
+export function applyTheme(theme: Theme): void {
+  const root = document.documentElement
+  if (theme === 'system') {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', theme)
+  }
+}
+
+// For useSyncExternalStore: notifies on our own writes (storeTheme) and on
+// writes from other tabs (the native 'storage' event).
+export function subscribeTheme(callback: () => void): () => void {
+  listeners.add(callback)
+  window.addEventListener('storage', callback)
+  return () => {
+    listeners.delete(callback)
+    window.removeEventListener('storage', callback)
+  }
+}
+
+// Inlined verbatim into _document.tsx as a blocking <script>, so it must
+// stay self-contained (no imports) and run before first paint to avoid a
+// flash of the wrong theme.
+export const themeInitScript = `(function () {
+  try {
+    var theme = window.localStorage.getItem('${STORAGE_KEY}');
+    if (theme === 'light' || theme === 'dark') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  } catch (e) {}
+})();`

--- a/main/pages/404.tsx
+++ b/main/pages/404.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import styles from '@/styles/Home.module.css'
+import ThemeToggle from '@/components/ThemeToggle'
 
 export default function NotFound() {
   return (
@@ -9,6 +10,7 @@ export default function NotFound() {
         <title>404 — War.re</title>
         <meta name="robots" content="noindex" />
       </Head>
+      <ThemeToggle />
       <main className={styles.main}>
         <div className={styles.center}>
           <h1>404</h1>

--- a/main/pages/_document.tsx
+++ b/main/pages/_document.tsx
@@ -1,10 +1,14 @@
 import { Html, Head, Main, NextScript } from 'next/document'
+import { themeInitScript } from '@/lib/theme'
 
 export default function Document() {
   return (
     <Html lang="en">
       <Head />
       <body>
+        {/* Runs before hydration so the saved theme applies on first paint,
+            with no flash of the wrong colors. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <Main />
         <NextScript />
       </body>

--- a/main/pages/n/index.tsx
+++ b/main/pages/n/index.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Image from 'next/image'
 import styles from '@/styles/Home.module.css'
 import Link from 'next/link'
+import ThemeToggle from '@/components/ThemeToggle'
 
 export default function Home() {
   return (
@@ -35,6 +36,7 @@ export default function Home() {
         <meta name="author" content="Ryan Warren" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <ThemeToggle />
       <main className={styles.main}>
         <div className={styles.center}>
           <h1>Ryan Warren</h1>

--- a/main/styles/Home.module.css
+++ b/main/styles/Home.module.css
@@ -66,11 +66,19 @@
 
 @media (prefers-color-scheme: dark) {
   /* The social icons are dark glyphs with no fill of their own. */
-  .images img {
+  :root:not([data-theme='light']) .images img {
     filter: invert(1);
   }
 
-  .info a:hover {
+  :root:not([data-theme='light']) .info a:hover {
     color: #a8a8a8;
   }
+}
+
+:root[data-theme='dark'] .images img {
+  filter: invert(1);
+}
+
+:root[data-theme='dark'] .info a:hover {
+  color: #a8a8a8;
 }

--- a/main/styles/globals.css
+++ b/main/styles/globals.css
@@ -39,11 +39,19 @@ a:focus-visible {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    /* Same staircase tile with the contrast flipped: #121212 base, #272727
-       steps. The light tile is opaque, so it can't be reused here. */
+  /* Same staircase tile with the contrast flipped: #121212 base, #272727
+     steps. The light tile is opaque, so it can't be reused here. An
+     explicit "light" choice (data-theme) overrides the system preference. */
+  :root:not([data-theme='light']) {
     background-image: url(/small_steps_dark.png);
     background-color: #121212;
     color: #e8e8e8;
   }
+}
+
+/* Explicit "dark" choice wins even when the system prefers light. */
+:root[data-theme='dark'] {
+  background-image: url(/small_steps_dark.png);
+  background-color: #121212;
+  color: #e8e8e8;
 }

--- a/subdomains/ryan/__tests__/ThemeToggle.test.tsx
+++ b/subdomains/ryan/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import ThemeToggle from '../components/ThemeToggle'
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('defaults to System with no explicit data-theme attribute', () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'true')
+    expect(document.documentElement).not.toHaveAttribute('data-theme')
+  })
+
+  it('choosing Dark saves the preference and applies it to the document', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+
+    expect(screen.getByRole('radio', { name: 'Dark' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'false')
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+    expect(window.localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('choosing Light saves the preference and applies it to the document', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Light' }))
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light')
+    expect(window.localStorage.getItem('theme')).toBe('light')
+  })
+
+  it('choosing System after an explicit choice clears the saved preference and the attribute', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'System' }))
+
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'true')
+    expect(document.documentElement).not.toHaveAttribute('data-theme')
+    expect(window.localStorage.getItem('theme')).toBeNull()
+  })
+})

--- a/subdomains/ryan/__tests__/ThemeToggle.test.tsx
+++ b/subdomains/ryan/__tests__/ThemeToggle.test.tsx
@@ -1,10 +1,19 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import ThemeToggle from '../components/ThemeToggle'
 
+// jsdom's window.scrollY is a getter with no setter, so tests drive it by
+// redefining the property before dispatching the scroll event the component
+// listens for.
+function scrollTo(y: number) {
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true })
+  fireEvent.scroll(window)
+}
+
 describe('ThemeToggle', () => {
   beforeEach(() => {
     window.localStorage.clear()
     document.documentElement.removeAttribute('data-theme')
+    scrollTo(0)
   })
 
   it('defaults to System with no explicit data-theme attribute', () => {
@@ -39,5 +48,58 @@ describe('ThemeToggle', () => {
     expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'true')
     expect(document.documentElement).not.toHaveAttribute('data-theme')
     expect(window.localStorage.getItem('theme')).toBeNull()
+  })
+
+  describe('scroll visibility', () => {
+    // Grab the region once, before it might become inert, and keep reusing
+    // that reference — an inert element may no longer match role queries.
+    function renderRegion() {
+      render(<ThemeToggle />)
+      return screen.getByRole('region', { name: 'Theme' })
+    }
+
+    it('is visible (not inert) at the top of the page', () => {
+      const region = renderRegion()
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('hides after scrolling down past the direction threshold', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+    })
+
+    it('reappears when scrolling back up', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(20)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('stays visible near the top even while scrolling down', () => {
+      const region = renderRegion()
+      scrollTo(5)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('reappears once scrolled back near the top', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(5)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('ignores scroll jitter below the direction threshold', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(52)
+      expect(region).toHaveAttribute('inert')
+    })
   })
 })

--- a/subdomains/ryan/components/ThemeToggle.module.css
+++ b/subdomains/ryan/components/ThemeToggle.module.css
@@ -2,12 +2,15 @@
   position: fixed;
   top: 0.75rem;
   right: 0.75rem;
-  display: inline-flex;
-  gap: 0.15rem;
   padding: 0.2rem;
   border-radius: 999px;
   background: rgba(127, 127, 127, 0.15);
   z-index: 10;
+}
+
+.group {
+  display: inline-flex;
+  gap: 0.15rem;
 }
 
 .toggle button {

--- a/subdomains/ryan/components/ThemeToggle.module.css
+++ b/subdomains/ryan/components/ThemeToggle.module.css
@@ -1,0 +1,43 @@
+.toggle {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  gap: 0.15rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  background: rgba(127, 127, 127, 0.15);
+  z-index: 10;
+}
+
+.toggle button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.7rem;
+  line-height: 1;
+  padding: 0.4rem 0.55rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.toggle button:hover {
+  background: rgba(127, 127, 127, 0.25);
+}
+
+.toggle .active {
+  background: rgba(127, 127, 127, 0.4);
+  font-weight: bold;
+}
+
+.toggle button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media print {
+  .toggle {
+    display: none;
+  }
+}

--- a/subdomains/ryan/components/ThemeToggle.module.css
+++ b/subdomains/ryan/components/ThemeToggle.module.css
@@ -6,6 +6,20 @@
   border-radius: 999px;
   background: rgba(127, 127, 127, 0.15);
   z-index: 10;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.toggle.hidden {
+  transform: translateY(-150%);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toggle {
+    transition: none;
+  }
 }
 
 .group {

--- a/subdomains/ryan/components/ThemeToggle.tsx
+++ b/subdomains/ryan/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from 'react'
+import styles from './ThemeToggle.module.css'
+import {
+  applyTheme,
+  getServerTheme,
+  getStoredTheme,
+  storeTheme,
+  subscribeTheme,
+  type Theme,
+} from '@/lib/theme'
+
+const OPTIONS: Array<{ value: Theme; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+]
+
+export default function ThemeToggle() {
+  // The server (and first client render, for hydration) always see
+  // 'system'; useSyncExternalStore then swaps in the real saved preference.
+  const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+
+  function choose(next: Theme) {
+    storeTheme(next)
+    applyTheme(next)
+  }
+
+  return (
+    <div className={styles.toggle} role="radiogroup" aria-label="Color theme">
+      {OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={theme === option.value}
+          className={theme === option.value ? styles.active : undefined}
+          onClick={() => choose(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/subdomains/ryan/components/ThemeToggle.tsx
+++ b/subdomains/ryan/components/ThemeToggle.tsx
@@ -34,19 +34,24 @@ export default function ThemeToggle() {
   }
 
   return (
-    <div className={styles.toggle} role="radiogroup" aria-label="Color theme">
-      {OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          role="radio"
-          aria-checked={theme === option.value}
-          className={theme === option.value ? styles.active : undefined}
-          onClick={() => choose(option.value)}
-        >
-          {option.label}
-        </button>
-      ))}
+    // A fixed-position control sitting outside the page's <main> needs its
+    // own landmark, or axe's "region" check flags it as content unreachable
+    // via landmark navigation — hence the wrapping role="region".
+    <div className={styles.toggle} role="region" aria-label="Theme">
+      <div className={styles.group} role="radiogroup" aria-label="Color theme">
+        {OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={theme === option.value}
+            className={theme === option.value ? styles.active : undefined}
+            onClick={() => choose(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/subdomains/ryan/components/ThemeToggle.tsx
+++ b/subdomains/ryan/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import styles from './ThemeToggle.module.css'
 import {
   applyTheme,
@@ -17,12 +17,20 @@ const OPTIONS: Array<{ value: Theme; label: string }> = [
 
 export default function ThemeToggle() {
   // The server (and first client render, for hydration) always see
-  // 'system'; useSyncExternalStore then swaps in the real saved preference.
+  // 'system'; useSyncExternalStore then swaps in the real saved preference
+  // — including a preference changed in another tab via the 'storage'
+  // event (see subscribeTheme).
   const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+
+  // Keep the DOM in sync with `theme` from any source — a click below, or
+  // a change made in another tab. Reapplying the already-current theme
+  // (e.g. right after hydration) is a harmless no-op.
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
 
   function choose(next: Theme) {
     storeTheme(next)
-    applyTheme(next)
   }
 
   return (

--- a/subdomains/ryan/components/ThemeToggle.tsx
+++ b/subdomains/ryan/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import styles from './ThemeToggle.module.css'
 import {
   applyTheme,
@@ -15,12 +15,22 @@ const OPTIONS: Array<{ value: Theme; label: string }> = [
   { value: 'dark', label: 'Dark' },
 ]
 
+// Below this scroll offset the toggle always shows, so it doesn't
+// flicker away from tiny scrolls (mobile bounce, sub-pixel jitter) right
+// at the top of the page.
+const ALWAYS_VISIBLE_BELOW_Y = 8
+// Minimum scroll delta (in either direction) before we react, so a resting
+// thumb or trackpad jitter can't toggle visibility on its own.
+const DIRECTION_THRESHOLD = 4
+
 export default function ThemeToggle() {
   // The server (and first client render, for hydration) always see
   // 'system'; useSyncExternalStore then swaps in the real saved preference
   // — including a preference changed in another tab via the 'storage'
   // event (see subscribeTheme).
   const theme = useSyncExternalStore(subscribeTheme, getStoredTheme, getServerTheme)
+  const [hidden, setHidden] = useState(false)
+  const lastScrollY = useRef(0)
 
   // Keep the DOM in sync with `theme` from any source — a click below, or
   // a change made in another tab. Reapplying the already-current theme
@@ -29,6 +39,28 @@ export default function ThemeToggle() {
     applyTheme(theme)
   }, [theme])
 
+  // Hide the toggle while scrolling down (it would otherwise sit over page
+  // content) and bring it back on scroll up or near the top.
+  useEffect(() => {
+    lastScrollY.current = window.scrollY
+
+    function onScroll() {
+      const y = window.scrollY
+      const delta = y - lastScrollY.current
+      if (y <= ALWAYS_VISIBLE_BELOW_Y) {
+        setHidden(false)
+      } else if (delta > DIRECTION_THRESHOLD) {
+        setHidden(true)
+      } else if (delta < -DIRECTION_THRESHOLD) {
+        setHidden(false)
+      }
+      lastScrollY.current = y
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
   function choose(next: Theme) {
     storeTheme(next)
   }
@@ -36,8 +68,15 @@ export default function ThemeToggle() {
   return (
     // A fixed-position control sitting outside the page's <main> needs its
     // own landmark, or axe's "region" check flags it as content unreachable
-    // via landmark navigation — hence the wrapping role="region".
-    <div className={styles.toggle} role="region" aria-label="Theme">
+    // via landmark navigation — hence the wrapping role="region". `inert`
+    // while hidden drops it from the tab order and hit-testing, so it can't
+    // trap keyboard focus or clicks while off-screen.
+    <div
+      className={hidden ? `${styles.toggle} ${styles.hidden}` : styles.toggle}
+      role="region"
+      aria-label="Theme"
+      inert={hidden || undefined}
+    >
       <div className={styles.group} role="radiogroup" aria-label="Color theme">
         {OPTIONS.map((option) => (
           <button

--- a/subdomains/ryan/lib/theme.ts
+++ b/subdomains/ryan/lib/theme.ts
@@ -1,0 +1,76 @@
+export type Theme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'theme'
+const listeners = new Set<() => void>()
+
+function isTheme(value: unknown): value is 'light' | 'dark' {
+  return value === 'light' || value === 'dark'
+}
+
+// Returns the user's saved preference, or 'system' if none was saved (the
+// default). Safe to call during server rendering — returns 'system'.
+export function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system'
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    return isTheme(value) ? value : 'system'
+  } catch {
+    // localStorage can throw (private browsing, disabled storage, etc).
+    return 'system'
+  }
+}
+
+// A stable 'system' snapshot for server rendering / hydration, so
+// useSyncExternalStore never sees a value that could mismatch the markup
+// the server produced.
+export function getServerTheme(): Theme {
+  return 'system'
+}
+
+export function storeTheme(theme: Theme): void {
+  try {
+    if (theme === 'system') {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, theme)
+    }
+  } catch {
+    // Ignore — the theme still applies for this page load via applyTheme.
+  }
+  listeners.forEach((listener) => listener())
+}
+
+// Reflects the chosen theme onto the document so CSS can key off it. Leaving
+// the attribute unset for 'system' lets the existing prefers-color-scheme
+// media queries keep driving the look.
+export function applyTheme(theme: Theme): void {
+  const root = document.documentElement
+  if (theme === 'system') {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', theme)
+  }
+}
+
+// For useSyncExternalStore: notifies on our own writes (storeTheme) and on
+// writes from other tabs (the native 'storage' event).
+export function subscribeTheme(callback: () => void): () => void {
+  listeners.add(callback)
+  window.addEventListener('storage', callback)
+  return () => {
+    listeners.delete(callback)
+    window.removeEventListener('storage', callback)
+  }
+}
+
+// Inlined verbatim into _document.tsx as a blocking <script>, so it must
+// stay self-contained (no imports) and run before first paint to avoid a
+// flash of the wrong theme.
+export const themeInitScript = `(function () {
+  try {
+    var theme = window.localStorage.getItem('${STORAGE_KEY}');
+    if (theme === 'light' || theme === 'dark') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  } catch (e) {}
+})();`

--- a/subdomains/ryan/pages/404.tsx
+++ b/subdomains/ryan/pages/404.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import styles from '@/styles/Home.module.css'
+import ThemeToggle from '@/components/ThemeToggle'
 
 export default function NotFound() {
   return (
@@ -9,6 +10,7 @@ export default function NotFound() {
         <title>404 — Ryan Warren</title>
         <meta name="robots" content="noindex" />
       </Head>
+      <ThemeToggle />
       <main className={styles.main}>
         <div className={styles.center}>
           <h1>404</h1>

--- a/subdomains/ryan/pages/_document.tsx
+++ b/subdomains/ryan/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document'
+import { themeInitScript } from '@/lib/theme'
 
 export default function Document() {
   return (
@@ -7,6 +8,9 @@ export default function Document() {
         <meta name="format-detection" content="telephone=no, date=no, email=no, address=no" />
       </Head>
       <body>
+        {/* Runs before hydration so the saved theme applies on first paint,
+            with no flash of the wrong colors. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <Main />
         <NextScript />
       </body>

--- a/subdomains/ryan/pages/n/index.tsx
+++ b/subdomains/ryan/pages/n/index.tsx
@@ -4,6 +4,7 @@ import Experience from '../../components/Experience'
 import Activity from '../../components/Activity'
 import ActivityList from '@/components/ActivityList'
 import ExperienceItem, { type ExperienceItemProps } from '@/components/ExperienceItem'
+import ThemeToggle from '@/components/ThemeToggle'
 
 export default function Home() {
   const technologies: ExperienceItemProps[] = [
@@ -59,6 +60,7 @@ export default function Home() {
         />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <ThemeToggle />
       <main className={styles.main}>
         <div className={styles.content}>
           <div className={styles.header}>

--- a/subdomains/ryan/styles/Home.module.css
+++ b/subdomains/ryan/styles/Home.module.css
@@ -26,9 +26,13 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .main h2 {
+  :root:not([data-theme='light']) .main h2 {
     border-bottom-color: #3a3f44;
   }
+}
+
+:root[data-theme='dark'] .main h2 {
+  border-bottom-color: #3a3f44;
 }
 
 .main h3 {

--- a/subdomains/ryan/styles/globals.css
+++ b/subdomains/ryan/styles/globals.css
@@ -18,18 +18,34 @@ a:focus-visible {
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
+  /* An explicit "light" choice (data-theme) overrides the system
+     preference. */
+  :root:not([data-theme='light']) body {
     background-color: #16181a;
     color: #dfe3e6;
   }
 
-  a {
+  :root:not([data-theme='light']) a {
     color: #8ab4f8;
   }
 
-  a:visited {
+  :root:not([data-theme='light']) a:visited {
     color: #b8a7e8;
   }
+}
+
+/* Explicit "dark" choice wins even when the system prefers light. */
+:root[data-theme='dark'] body {
+  background-color: #16181a;
+  color: #dfe3e6;
+}
+
+:root[data-theme='dark'] a {
+  color: #8ab4f8;
+}
+
+:root[data-theme='dark'] a:visited {
+  color: #b8a7e8;
 }
 
 @media print {


### PR DESCRIPTION
## Summary

Both apps (`main/` and `subdomains/ryan/`) already had dark mode via `prefers-color-scheme`. This adds an explicit toggle so visitors can pick **System** (default), **Light**, or **Dark**, with the choice persisted per-browser.

Each app gets an identical, independent implementation (consistent with the "one independent app per domain" convention):

- **`lib/theme.ts`** — reads/writes a `theme` key in `localStorage` (`'light' | 'dark'`, or absent for system-default); exposes `applyTheme`/`storeTheme`/`getStoredTheme`, plus `subscribeTheme`/`getServerTheme` for `useSyncExternalStore`.
- **`pages/_document.tsx`** — inlines a small blocking `<script>` (`themeInitScript`) that applies any saved theme to `<html data-theme>` before first paint, so there's no flash of the wrong theme.
- **`components/ThemeToggle.tsx`** — a System/Light/Dark control (`role="radiogroup"`), rendered fixed top-right on the content and 404 pages. Uses `useSyncExternalStore` (server/first-render snapshot is always `'system'`) so it hydrates cleanly with no mismatch and no effect-based `setState`.
- **CSS** — existing `@media (prefers-color-scheme: dark)` blocks are now guarded with `:not([data-theme='light'])`, and a parallel `:root[data-theme='dark']` block is added, so an explicit choice overrides the system preference in either direction while `system` (no attribute) keeps the old media-query behavior unchanged.

## Testing

Run in both `main/` and `subdomains/ryan/`:
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn format:check` ✅
- `yarn test` ✅ (existing suites unaffected)
- `yarn build` ✅ (static export; verified compiled CSS and the inline theme script in the exported HTML)

`yarn e2e` couldn't run in this sandbox — the pinned Playwright version doesn't match the pre-installed browser build here (pre-existing environment limitation, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMQnabB6msnwqgcUKK5JzR)_