### PR TITLE
Raise unit test coverage to 100% in both apps

### DIFF
--- a/main/__tests__/ThemeToggle.test.tsx
+++ b/main/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import ThemeToggle from '../components/ThemeToggle'
+
+// jsdom's window.scrollY is a getter with no setter, so tests drive it by
+// redefining the property before dispatching the scroll event the component
+// listens for.
+function scrollTo(y: number) {
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true })
+  fireEvent.scroll(window)
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    scrollTo(0)
+  })
+
+  it('defaults to System with no explicit data-theme attribute', () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'true')
+    expect(document.documentElement).not.toHaveAttribute('data-theme')
+  })
+
+  it('choosing Dark saves the preference and applies it to the document', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+
+    expect(screen.getByRole('radio', { name: 'Dark' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'false')
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+    expect(window.localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('choosing Light saves the preference and applies it to the document', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Light' }))
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light')
+    expect(window.localStorage.getItem('theme')).toBe('light')
+  })
+
+  it('choosing System after an explicit choice clears the saved preference and the attribute', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'System' }))
+
+    expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'true')
+    expect(document.documentElement).not.toHaveAttribute('data-theme')
+    expect(window.localStorage.getItem('theme')).toBeNull()
+  })
+
+  describe('scroll visibility', () => {
+    // Grab the region once, before it might become inert, and keep reusing
+    // that reference — an inert element may no longer match role queries.
+    function renderRegion() {
+      render(<ThemeToggle />)
+      return screen.getByRole('region', { name: 'Theme' })
+    }
+
+    it('is visible (not inert) at the top of the page', () => {
+      const region = renderRegion()
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('hides after scrolling down past the direction threshold', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+    })
+
+    it('reappears when scrolling back up', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(20)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('stays visible near the top even while scrolling down', () => {
+      const region = renderRegion()
+      scrollTo(5)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('reappears once scrolled back near the top', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(5)
+      expect(region).not.toHaveAttribute('inert')
+    })
+
+    it('ignores scroll jitter below the direction threshold', () => {
+      const region = renderRegion()
+      scrollTo(50)
+      expect(region).toHaveAttribute('inert')
+
+      scrollTo(52)
+      expect(region).toHaveAttribute('inert')
+    })
+  })
+})

--- a/main/__tests__/theme.server.test.ts
+++ b/main/__tests__/theme.server.test.ts
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+import { getStoredTheme } from '../lib/theme'
+
+// getStoredTheme's `typeof window === 'undefined'` guard only runs during
+// actual server rendering — jsdom always defines `window`, so it needs a
+// real "no window" environment to exercise.
+describe('getStoredTheme on the server', () => {
+  it('returns system without touching window', () => {
+    expect(getStoredTheme()).toBe('system')
+  })
+})

--- a/main/__tests__/theme.test.ts
+++ b/main/__tests__/theme.test.ts
@@ -1,0 +1,152 @@
+import {
+  applyTheme,
+  getServerTheme,
+  getStoredTheme,
+  storeTheme,
+  subscribeTheme,
+  themeInitScript,
+} from '../lib/theme'
+
+describe('theme', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  describe('getServerTheme', () => {
+    it('always returns system (the SSR/hydration-safe snapshot)', () => {
+      expect(getServerTheme()).toBe('system')
+    })
+  })
+
+  describe('getStoredTheme', () => {
+    it('returns system when nothing has been saved', () => {
+      expect(getStoredTheme()).toBe('system')
+    })
+
+    it('returns the saved theme', () => {
+      window.localStorage.setItem('theme', 'dark')
+      expect(getStoredTheme()).toBe('dark')
+
+      window.localStorage.setItem('theme', 'light')
+      expect(getStoredTheme()).toBe('light')
+    })
+
+    it('falls back to system for an unrecognized stored value', () => {
+      window.localStorage.setItem('theme', 'blue')
+      expect(getStoredTheme()).toBe('system')
+    })
+
+    it('falls back to system when localStorage throws', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      expect(getStoredTheme()).toBe('system')
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('storeTheme', () => {
+    it('removes the saved preference for system', () => {
+      window.localStorage.setItem('theme', 'dark')
+      storeTheme('system')
+      expect(window.localStorage.getItem('theme')).toBeNull()
+    })
+
+    it('saves an explicit preference', () => {
+      storeTheme('light')
+      expect(window.localStorage.getItem('theme')).toBe('light')
+
+      storeTheme('dark')
+      expect(window.localStorage.getItem('theme')).toBe('dark')
+    })
+
+    it('notifies subscribers', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+      storeTheme('dark')
+      expect(listener).toHaveBeenCalledTimes(1)
+      unsubscribe()
+    })
+
+    it('still notifies subscribers when localStorage throws', () => {
+      jest.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+
+      expect(() => storeTheme('dark')).not.toThrow()
+      expect(listener).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('applyTheme', () => {
+    it('removes data-theme for system', () => {
+      document.documentElement.setAttribute('data-theme', 'dark')
+      applyTheme('system')
+      expect(document.documentElement).not.toHaveAttribute('data-theme')
+    })
+
+    it('sets data-theme for an explicit theme', () => {
+      applyTheme('dark')
+      expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+
+      applyTheme('light')
+      expect(document.documentElement).toHaveAttribute('data-theme', 'light')
+    })
+  })
+
+  describe('subscribeTheme', () => {
+    it('notifies on a storage event from another tab', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+
+      window.dispatchEvent(new Event('storage'))
+      expect(listener).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+    })
+
+    it('stops notifying once unsubscribed', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+      unsubscribe()
+
+      storeTheme('dark')
+      window.dispatchEvent(new Event('storage'))
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('themeInitScript', () => {
+    // Inlined verbatim into _document.tsx (see lib/theme.ts) and run as a
+    // blocking <script> before hydration, so it never goes through the
+    // module's own exported functions — run it directly to pin its behavior.
+    function run() {
+      new Function(themeInitScript)()
+    }
+
+    it('applies a saved explicit theme before first paint', () => {
+      window.localStorage.setItem('theme', 'dark')
+      run()
+      expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+    })
+
+    it('leaves data-theme unset with no saved preference', () => {
+      run()
+      expect(document.documentElement).not.toHaveAttribute('data-theme')
+    })
+
+    it('does not throw when localStorage is unavailable', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      expect(run).not.toThrow()
+      jest.restoreAllMocks()
+    })
+  })
+})

--- a/main/jest.config.js
+++ b/main/jest.config.js
@@ -9,9 +9,10 @@ module.exports = createJestConfig({
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   // Playwright specs live in e2e/ and run via `yarn e2e`, not Jest.
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/e2e/'],
-  // The content page (`pages/n`) is the only one with body markup worth unit
-  // testing; the redirect shell and Next internals are covered by `yarn e2e`.
-  collectCoverageFrom: ['pages/n/**/*.{ts,tsx}'],
+  // The content page (`pages/n`), the theme components, and the theme
+  // storage module are the units worth testing here; the redirect shell,
+  // 404 page, and Next internals are covered by `yarn e2e`.
+  collectCoverageFrom: ['pages/n/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}', 'lib/**/*.ts'],
   coverageThreshold: {
     global: {
       statements: 90,

--- a/subdomains/ryan/__tests__/theme.server.test.ts
+++ b/subdomains/ryan/__tests__/theme.server.test.ts
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+import { getStoredTheme } from '../lib/theme'
+
+// getStoredTheme's `typeof window === 'undefined'` guard only runs during
+// actual server rendering — jsdom always defines `window`, so it needs a
+// real "no window" environment to exercise.
+describe('getStoredTheme on the server', () => {
+  it('returns system without touching window', () => {
+    expect(getStoredTheme()).toBe('system')
+  })
+})

--- a/subdomains/ryan/__tests__/theme.test.ts
+++ b/subdomains/ryan/__tests__/theme.test.ts
@@ -1,0 +1,152 @@
+import {
+  applyTheme,
+  getServerTheme,
+  getStoredTheme,
+  storeTheme,
+  subscribeTheme,
+  themeInitScript,
+} from '../lib/theme'
+
+describe('theme', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  describe('getServerTheme', () => {
+    it('always returns system (the SSR/hydration-safe snapshot)', () => {
+      expect(getServerTheme()).toBe('system')
+    })
+  })
+
+  describe('getStoredTheme', () => {
+    it('returns system when nothing has been saved', () => {
+      expect(getStoredTheme()).toBe('system')
+    })
+
+    it('returns the saved theme', () => {
+      window.localStorage.setItem('theme', 'dark')
+      expect(getStoredTheme()).toBe('dark')
+
+      window.localStorage.setItem('theme', 'light')
+      expect(getStoredTheme()).toBe('light')
+    })
+
+    it('falls back to system for an unrecognized stored value', () => {
+      window.localStorage.setItem('theme', 'blue')
+      expect(getStoredTheme()).toBe('system')
+    })
+
+    it('falls back to system when localStorage throws', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      expect(getStoredTheme()).toBe('system')
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('storeTheme', () => {
+    it('removes the saved preference for system', () => {
+      window.localStorage.setItem('theme', 'dark')
+      storeTheme('system')
+      expect(window.localStorage.getItem('theme')).toBeNull()
+    })
+
+    it('saves an explicit preference', () => {
+      storeTheme('light')
+      expect(window.localStorage.getItem('theme')).toBe('light')
+
+      storeTheme('dark')
+      expect(window.localStorage.getItem('theme')).toBe('dark')
+    })
+
+    it('notifies subscribers', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+      storeTheme('dark')
+      expect(listener).toHaveBeenCalledTimes(1)
+      unsubscribe()
+    })
+
+    it('still notifies subscribers when localStorage throws', () => {
+      jest.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+
+      expect(() => storeTheme('dark')).not.toThrow()
+      expect(listener).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe('applyTheme', () => {
+    it('removes data-theme for system', () => {
+      document.documentElement.setAttribute('data-theme', 'dark')
+      applyTheme('system')
+      expect(document.documentElement).not.toHaveAttribute('data-theme')
+    })
+
+    it('sets data-theme for an explicit theme', () => {
+      applyTheme('dark')
+      expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+
+      applyTheme('light')
+      expect(document.documentElement).toHaveAttribute('data-theme', 'light')
+    })
+  })
+
+  describe('subscribeTheme', () => {
+    it('notifies on a storage event from another tab', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+
+      window.dispatchEvent(new Event('storage'))
+      expect(listener).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+    })
+
+    it('stops notifying once unsubscribed', () => {
+      const listener = jest.fn()
+      const unsubscribe = subscribeTheme(listener)
+      unsubscribe()
+
+      storeTheme('dark')
+      window.dispatchEvent(new Event('storage'))
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('themeInitScript', () => {
+    // Inlined verbatim into _document.tsx (see lib/theme.ts) and run as a
+    // blocking <script> before hydration, so it never goes through the
+    // module's own exported functions — run it directly to pin its behavior.
+    function run() {
+      new Function(themeInitScript)()
+    }
+
+    it('applies a saved explicit theme before first paint', () => {
+      window.localStorage.setItem('theme', 'dark')
+      run()
+      expect(document.documentElement).toHaveAttribute('data-theme', 'dark')
+    })
+
+    it('leaves data-theme unset with no saved preference', () => {
+      run()
+      expect(document.documentElement).not.toHaveAttribute('data-theme')
+    })
+
+    it('does not throw when localStorage is unavailable', () => {
+      jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+      expect(run).not.toThrow()
+      jest.restoreAllMocks()
+    })
+  })
+})

--- a/subdomains/ryan/components/Activity.tsx
+++ b/subdomains/ryan/components/Activity.tsx
@@ -30,6 +30,10 @@ function formatDuration(start: string, end: string): string | null {
     parts.push(`${interval.years} ${pluralize('Year', interval.years)}`)
   if (interval.months && interval.months > 0)
     parts.push(`${interval.months} ${pluralize('Month', interval.months)}`)
+  // parts is never empty here: startDate <= endDate is already guaranteed
+  // above, and the +1 month in the interval means even a same-month span
+  // counts as 1 month. Kept as a defensive fallback rather than assumed away.
+  /* istanbul ignore next */
   return parts.length > 0 ? parts.join(' ') : null
 }
 

--- a/subdomains/ryan/jest.config.js
+++ b/subdomains/ryan/jest.config.js
@@ -10,10 +10,11 @@ module.exports = createJestConfig({
   // Playwright specs live in e2e/ and run via `yarn e2e`, not Jest.
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/e2e/'],
   coverageReporters: ['text', 'lcov'],
-  // Coverage is gated on components/, where the unit tests live. The `pages/`
-  // tree is verified end-to-end by the Playwright smoke tests (`yarn e2e`), so
-  // including it in the Jest coverage gate would misrepresent what Jest checks.
-  collectCoverageFrom: ['components/**/*.{ts,tsx}'],
+  // Coverage is gated on components/, lib/, and the content page (`pages/n`)
+  // — the units with body markup or logic worth unit testing. The redirect
+  // shell, 404 page, and Next internals are covered end-to-end instead
+  // (`yarn e2e`), so including them here would misrepresent what Jest checks.
+  collectCoverageFrom: ['components/**/*.{ts,tsx}', 'lib/**/*.ts', 'pages/n/**/*.{ts,tsx}'],
   coverageThreshold: {
     global: {
       statements: 90,


### PR DESCRIPTION
## Summary

Codecov showed `main` at 70% and `subdomains/ryan` at 83%. Both apps split coverage between Jest unit tests (gated at 90%) and Playwright e2e V8 coverage (`main-e2e`/`ryan-e2e`, informational). The actual gaps were in files that were either untested or excluded from the Jest coverage gate even though they had, or could easily have, solid unit tests:

- **`main/components/ThemeToggle.tsx`** had no unit tests at all — `subdomains/ryan` already had a full `ThemeToggle.test.tsx` (click each theme option, scroll show/hide behavior) that `main` was missing.
- **`lib/theme.ts`** (identical in both apps) wasn't unit tested or included in either app's `collectCoverageFrom`, including its `localStorage`-throws fallbacks, the `storage`-event listener, and the inlined `themeInitScript`.
- **`getStoredTheme`'s SSR branch** (`typeof window === 'undefined'`) can never run under jsdom or a real browser — it needs a `@jest-environment node` test.
- **`ryan`'s `pages/n`** was already fully exercised by `Home.test.tsx` but excluded from `collectCoverageFrom`, so it didn't count.
- **`ryan`'s `Activity.tsx`** had one truly unreachable branch (`parts.length > 0 ? ... : null` can never take the `null` path, since the inclusive month counting a few lines above guarantees at least one part) — marked with `istanbul ignore next` and a comment explaining why.

## Changes

- `main/__tests__/ThemeToggle.test.tsx` — new, mirrors the existing `ryan` suite.
- `main/__tests__/theme.test.ts` — new, covers `getStoredTheme`/`storeTheme`/`getServerTheme`/`applyTheme`/`subscribeTheme`/`themeInitScript`, including `localStorage` throwing.
- `main/__tests__/theme.server.test.ts` + `subdomains/ryan/__tests__/theme.server.test.ts` — new, `@jest-environment node` tests for the SSR branch.
- `subdomains/ryan/__tests__/theme.test.ts` — new, same coverage as main's for the shared `lib/theme.ts`.
- `main/jest.config.js` — `collectCoverageFrom` now also includes `components/**` and `lib/**`.
- `subdomains/ryan/jest.config.js` — `collectCoverageFrom` now also includes `lib/**` and `pages/n/**`.
- `subdomains/ryan/components/Activity.tsx` — `istanbul ignore next` on the one unreachable branch, with a comment.

## Result

Both apps now report **100% statements/branches/functions/lines** from `yarn test:coverage`:

```
main:  components/ThemeToggle.tsx, lib/theme.ts, pages/n/index.tsx — 100/100/100/100
ryan:  components/*, lib/theme.ts, pages/n/index.tsx — 100/100/100/100
```

`main-e2e`/`ryan-e2e` Playwright coverage is untouched — it still covers the redirect shell, 404 page, and `_app`/`_document` Next internals, which remain e2e's job per the existing repo convention.

## Testing

- `yarn test:coverage --ci`, `yarn lint`, `yarn typecheck`, `yarn format:check`, `yarn build` — all green in both `main/` and `subdomains/ryan/`.
- `yarn e2e:coverage` re-run in `main/` to confirm no regression in the existing Playwright suite.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121p27CNDPGFP1RNJn86bbs

---
_Generated by [Claude Code](https://claude.ai/code/session_0121p27CNDPGFP1RNJn86bbs)_